### PR TITLE
enable cors by default #16

### DIFF
--- a/lib/hapi_server.coffee
+++ b/lib/hapi_server.coffee
@@ -76,7 +76,7 @@ class HapiGER
   init_server: (esm = 'mem') ->
     #SETUP SERVER
     @_server = new Hapi.Server()
-    @_server.connection({ port: @options.port });
+    @_server.connection({ port: @options.port, routes: { cors:true } });
     @info = @_server.info
 
   setup_server: ->


### PR DESCRIPTION
cors enabled by default so hapiger might be used from different domains via xhr calls